### PR TITLE
Add blank attribute for external link

### DIFF
--- a/donations.html
+++ b/donations.html
@@ -77,12 +77,14 @@
             <li>
               <strong>Boosty</strong>
               <br/>
-              <a href="https://boosty.to/the2pizza/">the2pizza</a>
+              <a href="https://boosty.to/the2pizza/" target="_blank"
+              rel="noopener noreferrer">the2pizza</a>
             </li>
             <li>
                 <strong>Patreon</strong>
                 <br/>
-                <a href="https://www.patreon.com/2pizza">2pizza</a>
+                <a href="https://www.patreon.com/2pizza" target="_blank"
+                rel="noopener noreferrer">2pizza</a>
             </li>
           </ul>
         </div>
@@ -93,7 +95,8 @@
       <div class="footer-wrapper">
         <section class="footer-content">
           <p class="white-text">Vive la résistance<br>
-            <span class="lng-contacts">Обратная связь - </span> <a class="main__links white-text" href="https://t.me/kira2pizza">Telegram</a>
+            <span class="lng-contacts">Обратная связь - </span> <a class="main__links white-text" href="https://t.me/kira2pizza" target="_blank"
+            rel="noopener noreferrer">Telegram</a>
             <a class="main__links white-text" href="mailto:the2pizza@proton.me">E-mail</a>
         </section>
       </div>

--- a/index.html
+++ b/index.html
@@ -37,7 +37,8 @@
         <h2 class="lng-welcome">Cвободный VPN для свободных людей.</h2>
         <p class="welcome-text">
         <span class="lng-welcome-text1">Мы за свободу слова и против какой-либо цензуры.</span><br/>
-        <span class="lng-welcome-text2">Делаем некомерческий</span> <a href="https://ru.wikipedia.org/wiki/VPN">VPN </a><span class="lng-welcome-text3">, не собирающий никаких данных.</span> <br/> <br/>
+        <span class="lng-welcome-text2">Делаем некомерческий</span> <a href="https://ru.wikipedia.org/wiki/VPN" target="_blank"
+        rel="noopener noreferrer">VPN </a><span class="lng-welcome-text3">, не собирающий никаких данных.</span> <br/> <br/>
         <span class="lng-welcome-text4">Сегодня свобода слова особенно уязвима,
         независимые СМИ запрещены, людям промывают мозги пропагандой,
         сервисы ВПН блокируют, выражать свою позицию и мнение опасно.
@@ -50,7 +51,8 @@
       <section class="install-section">
         <div class="link-container">
           <li>
-            <a class="lng-link-install main__links" href="https://github.com/nezavisimost/FuckRKN1/blob/main/README-ru.md">Инструкция по установке</a>
+            <a class="lng-link-install main__links" href="https://github.com/nezavisimost/FuckRKN1/blob/main/README-ru.md" target="_blank"
+            rel="noopener noreferrer">Инструкция по установке</a>
           </li>
         </div>
       </section>
@@ -59,17 +61,20 @@
     <section class="card paddings two-columns-grid">
       <ul class="links-list">
         <li>
-          <a class="bold-text" href="https://t.me/FuckRKN1">
+          <a class="bold-text" href="https://t.me/FuckRKN1" target="_blank"
+          rel="noopener noreferrer">
             Telegram
           </a>
         </li>
         <li>
-          <a class="bold-text" href="https://twitter.com/FuckRKN1">
+          <a class="bold-text" href="https://twitter.com/FuckRKN1" target="_blank"
+          rel="noopener noreferrer">
             Twitter
           </a>
         </li>
         <li>
-          <a class="bold-text" href="https://github.com/nezavisimost/FuckRKN1">
+          <a class="bold-text" href="https://github.com/nezavisimost/FuckRKN1" target="_blank"
+          rel="noopener noreferrer">
             GitHub
           </a>
         </li>
@@ -89,12 +94,14 @@
             <li>
                 <strong>Boosty</strong>
                 <br/>
-                <a href="https://boosty.to/the2pizza/">the2pizza</a>
+                <a href="https://boosty.to/the2pizza/" target="_blank"
+                rel="noopener noreferrer">the2pizza</a>
             </li>
             <li>
                 <strong>Patreon</strong>
                 <br/>
-                <a href="https://www.patreon.com/2pizza">2pizza</a>
+                <a href="https://www.patreon.com/2pizza" target="_blank"
+                rel="noopener noreferrer">2pizza</a>
             </li>
             <li>
               <a class="bold-text lng-donation2" href="donations.html">Больше способов</a></li>
@@ -107,7 +114,8 @@
     <div class="footer-wrapper">
       <section class="footer-content">
         <p class="white-text">Vive la résistance<br>
-          <span class="lng-contacts">Обратная связь - </span> <a class="main__links white-text" href="https://t.me/kira2pizza">Telegram</a>
+          <span class="lng-contacts">Обратная связь - </span> <a class="main__links white-text" href="https://t.me/kira2pizza" target="_blank"
+          rel="noopener noreferrer">Telegram</a>
           <a class="main__links white-text" href="mailto:the2pizza@proton.me">E-mail</a>
       </section>
     </div>


### PR DESCRIPTION
Added `target="_blank"` attribute for external links to open in new tabs,  for index.html and donation.html. And this is predictable behavior for UX.
Added `rel="noopener noreferrer"` attribute, so that external sites do not learn too much about the current page at the time of opening.

