### PR TITLE
remembering the language selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+package-lock.json

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,22 +1,15 @@
-import { createContext, Dispatch, SetStateAction, useState } from 'react';
+
 import './App.css';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import Home from './routes/Home';
 import Donate from './routes/Donate';
 import NotFound from './routes/NotFound';
-
-interface DataContextType {
-  lang: string;
-  setLang: Dispatch<SetStateAction<string>>;
-}
-
-export const DataContext = createContext<DataContextType | null>(null);
+import {DataProvider} from "./providers/DataProvider";
 
 function App() {
-  const [lang, setLang] = useState('ru');
 
   return (
-    <DataContext.Provider value={{ lang, setLang }}>
+    <DataProvider>
       <BrowserRouter>
         <Routes>
           <Route path="/" element={<Home />} />
@@ -26,7 +19,7 @@ function App() {
           <Route path="*" element={<NotFound />} />
         </Routes>
       </BrowserRouter>
-    </DataContext.Provider>
+    </DataProvider>
   );
 }
 

--- a/src/components/LangSwitch.tsx
+++ b/src/components/LangSwitch.tsx
@@ -1,11 +1,7 @@
 import React from 'react';
+import {ILanguage} from "../hooks/useLanguage";
 
-interface SwitchProps {
-  lang: string;
-  setLang: React.Dispatch<React.SetStateAction<string>>;
-}
-
-const LangSwitch = ({ lang, setLang }: SwitchProps) => {
+const LangSwitch = ({ lang, setLang }: ILanguage) => {
   return (
     <div className="flex">
       <div

--- a/src/components/MailchimpForm.tsx
+++ b/src/components/MailchimpForm.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useEffect, useState } from 'react';
-import { DataContext } from '../App';
+import { DataContext } from '../providers/DataProvider';
 import { content } from '../content/subscribe';
 
 interface FormProps {

--- a/src/components/NavLinks.tsx
+++ b/src/components/NavLinks.tsx
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react';
 import { NavLink, useLocation } from 'react-router-dom';
-import { DataContext } from '../App';
+import { DataContext } from '../providers/DataProvider';
 import { Lang, links } from '../content/navbar';
 
 const NavLinks = () => {

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,13 +1,12 @@
 import React, { useContext, useEffect, useState } from 'react';
 import { Link, NavLink, useLocation } from 'react-router-dom';
-import { DataContext } from '../App';
+import { DataContext } from '../providers/DataProvider';
 import Button from './Button';
 import LangSwitch from './LangSwitch';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faBars, faXmark } from '@fortawesome/free-solid-svg-icons';
 import MailchimpFormContainer from './MailchimpFormContainer';
 import { content } from '../content/home';
-import { Lang, links } from '../content/navbar';
 import NavLinks from './NavLinks';
 
 const Navbar = () => {

--- a/src/hooks/useLanguage.ts
+++ b/src/hooks/useLanguage.ts
@@ -1,0 +1,32 @@
+import {useState} from 'react';
+
+
+export interface ILanguage {
+	lang: 'ru' | 'en';
+	setLang: (lang: 'ru' | 'en') => void;
+
+}
+
+function useLanguage(): ILanguage {
+	const [language, setLanguage] = useState<ILanguage["lang"]>(valueFromLocalStorage());
+	const changeLanguage = (lang: ILanguage["lang"]) => {
+		setLanguage(lang);
+		localStorage.setItem('language', lang);
+	}
+
+	function valueFromLocalStorage() //get value from localStorage or default value
+	{
+		const localStorageValue: string = localStorage.getItem('language') || '';
+		if (localStorageValue !== '' && (localStorageValue == 'ru' || localStorageValue == 'en'))
+			return localStorageValue;
+		else {
+			//if there is an invalid value in the local storage, then set the default value to 'ru'
+			localStorage.setItem('language', 'ru');
+			return 'ru';
+		}
+	}
+
+	return {lang: language, setLang: changeLanguage};
+}
+
+export default useLanguage;

--- a/src/providers/DataProvider.tsx
+++ b/src/providers/DataProvider.tsx
@@ -1,0 +1,24 @@
+import React, {createContext} from "react";
+import useLanguage, {ILanguage} from "../hooks/useLanguage";
+
+type Props = {
+	children: React.ReactNode | React.ReactNode[] | null | undefined;
+};
+
+const DataContext = createContext<ILanguage | null>(null);
+const DataProvider = ({children}: Props) => {
+	const {lang, setLang} = useLanguage();
+	return (
+		<DataContext.Provider value={{
+			lang: lang,
+			setLang: setLang
+		}
+		}>
+			{children}
+		</DataContext.Provider>)
+};
+
+export {
+	DataContext,
+	DataProvider
+};

--- a/src/routes/Donate.tsx
+++ b/src/routes/Donate.tsx
@@ -1,6 +1,6 @@
 import { useContext } from 'react';
 import { Link } from 'react-router-dom';
-import { DataContext } from '../App';
+import { DataContext } from '../providers/DataProvider';
 import { content } from '../content/donate';
 import DonateCard from '../components/DonateCard';
 import Navbar from '../components/Navbar';

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -5,7 +5,7 @@ import {
 } from '@fortawesome/free-brands-svg-icons';
 import { useContext, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { DataContext } from '../App';
+import { DataContext } from '../providers/DataProvider';
 import Button from '../components/Button';
 import LangSwitch from '../components/LangSwitch';
 import SocialLink from '../components/SocialLink';

--- a/src/routes/NotFound.tsx
+++ b/src/routes/NotFound.tsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { DataContext } from '../App';
+import { DataContext } from '../providers/DataProvider';
 import Button from '../components/Button';
 import NavLinks from '../components/NavLinks';
 import { content } from '../content/home';
@@ -9,7 +9,7 @@ import { notFound } from '../content/notFound';
 const NotFound = () => {
   const appContext = useContext(DataContext);
   if (!appContext) return null;
-  const { lang, setLang } = appContext;
+  const { lang} = appContext;
   console.log(lang);
 
   return (


### PR DESCRIPTION
Added a custom hook for working with the language.
The language selection is saved to local memory. The next time the page loads, the language has not changed.

Also, the language provider is allocated to a separate component.

Now we need to import
DataContext from "../providers/DataContext";

Everything else is compatible.