### PR TITLE
fix: re-render of the `Installation` page

### DIFF
--- a/src/components/PlatformsInstruction.tsx
+++ b/src/components/PlatformsInstruction.tsx
@@ -1,0 +1,42 @@
+import { useState, useRef, useCallback } from "react";
+
+import PlatformNavigation from './PlatformNavigation';
+import Instructions from './Instructions/Instructions';
+
+import useWindowDimensions from "../hooks/useDementions";
+
+import getOS from "../utils/getOS";
+
+const MOBILE_BREACKPOINT = 768;
+
+const PlatformsInstruction = () => {
+    const { width: screenWidth } = useWindowDimensions();
+
+    const [platform, setPlatform] = useState<string>(getOS());
+    const articleRef = useRef<HTMLElement>(null);
+
+    const platformHandler = useCallback((platform: string) => {
+        setPlatform(platform);
+
+        if (screenWidth < MOBILE_BREACKPOINT) {
+            scrollCallback();
+        }
+    }, []);
+
+    function scrollCallback() {
+        if (!articleRef.current) throw Error("articleRef is not assigned");
+        articleRef.current.scrollIntoView({ behavior: "smooth" });
+    }
+
+    return (
+        <>
+            <PlatformNavigation
+                onSetPlatform={platformHandler}
+                activePlatform={platform}
+            />
+            <Instructions platform={platform} refProps={articleRef} />
+        </>
+    )
+};
+
+export default PlatformsInstruction;

--- a/src/components/PlatformsInstruction.tsx
+++ b/src/components/PlatformsInstruction.tsx
@@ -6,27 +6,23 @@ import Instructions from './Instructions/Instructions';
 import useWindowDimensions from "../hooks/useDementions";
 
 import getOS from "../utils/getOS";
+import scrollToElement from "../utils/scrollToElement";
 
 const MOBILE_BREACKPOINT = 768;
 
 const PlatformsInstruction = () => {
     const { width: screenWidth } = useWindowDimensions();
 
-    const [platform, setPlatform] = useState<string>(getOS());
+    const [platform, setPlatform] = useState(getOS());
     const articleRef = useRef<HTMLElement>(null);
 
     const platformHandler = useCallback((platform: string) => {
         setPlatform(platform);
 
-        if (screenWidth < MOBILE_BREACKPOINT) {
-            scrollCallback();
+        if (screenWidth < MOBILE_BREACKPOINT && articleRef.current) {
+            scrollToElement(articleRef.current);
         }
-    }, []);
-
-    function scrollCallback() {
-        if (!articleRef.current) throw Error("articleRef is not assigned");
-        articleRef.current.scrollIntoView({ behavior: "smooth" });
-    }
+    }, [screenWidth]);
 
     return (
         <>

--- a/src/routes/Installation.tsx
+++ b/src/routes/Installation.tsx
@@ -1,53 +1,15 @@
-import { useContext, useState, useRef } from "react";
+import { useContext } from "react";
 
 import { DataContext } from "../providers/DataProvider";
 import { content } from "../content/instructions";
 import Navbar from "../components/Navbar";
-import PlatformNavigation from "../components/PlatformNavigation";
-import Instructions from "../components/Instructions/Instructions";
-import useWindowDimensions from "../hooks/useDementions";
 
-const MOBILE_BREACKPOINT = 768;
+import PlatformsInstruction from "../components/PlatformsInstruction";
 
 const Installation = () => {
   const appContext = useContext(DataContext);
   if (!appContext) return null;
   const { lang } = appContext;
-
-  const { width: screenWidth } = useWindowDimensions();
-
-  const [platform, setPlatform] = useState<string>(getOS());
-  const articleRef = useRef<HTMLElement>(null);
-
-  function getOS(): string {
-    let userAgent = window.navigator.userAgent,
-      platform = window.navigator.platform,
-      macosPlatforms = ["Macintosh", "MacIntel", "MacPPC", "Mac68K"],
-      windowsPlatforms = ["Win32", "Win64", "Windows", "WinCE"],
-      iosPlatforms = ["iPhone", "iPad", "iPod"];
-
-    if (macosPlatforms.indexOf(platform) !== -1) {
-      return "macos";
-    } else if (iosPlatforms.indexOf(platform) !== -1) {
-      return "ios";
-    } else if (windowsPlatforms.indexOf(platform) !== -1) {
-      return "windows";
-    } else if (/Android/.test(userAgent)) {
-      return "android";
-    } else return "linux";
-  }
-
-  function platformHandler(platform: string) {
-    setPlatform(platform);
-    if (screenWidth < MOBILE_BREACKPOINT) {
-      scrollCallback();
-    }
-  }
-
-  function scrollCallback() {
-    if (!articleRef.current) throw Error("articleRef is not assigned");
-    articleRef.current.scrollIntoView({ behavior: "smooth" });
-  }
 
   return (
     <div className="min-h-screen flex flex-col md:max-w-xl lg:max-w-6xl mx-auto">
@@ -56,11 +18,7 @@ const Installation = () => {
         <h1 className="font-semibold text-3xl lg:text-[40px] text-zinc-800 mt-6 whitespace-pre-wrap mb-12">
           {content.header[lang]}
         </h1>
-        <PlatformNavigation
-          onSetPlatform={platformHandler}
-          activePlatform={platform}
-        />
-        <Instructions platform={platform} refProps={articleRef} />
+        <PlatformsInstruction />
       </main>
     </div>
   );

--- a/src/utils/getOS.ts
+++ b/src/utils/getOS.ts
@@ -1,0 +1,19 @@
+function getOS(): string {
+    let userAgent = window.navigator.userAgent,
+      platform = window.navigator.platform,
+      macosPlatforms = ["Macintosh", "MacIntel", "MacPPC", "Mac68K"],
+      windowsPlatforms = ["Win32", "Win64", "Windows", "WinCE"],
+      iosPlatforms = ["iPhone", "iPad", "iPod"];
+
+    if (macosPlatforms.indexOf(platform) !== -1) {
+      return "macos";
+    } else if (iosPlatforms.indexOf(platform) !== -1) {
+      return "ios";
+    } else if (windowsPlatforms.indexOf(platform) !== -1) {
+      return "windows";
+    } else if (/Android/.test(userAgent)) {
+      return "android";
+    } else return "linux";
+}
+
+export default getOS;

--- a/src/utils/scrollToElement.ts
+++ b/src/utils/scrollToElement.ts
@@ -1,0 +1,5 @@
+function scrollToElement(element: HTMLElement) {
+    element.scrollIntoView({ behavior: "smooth" });
+}
+
+export default scrollToElement;


### PR DESCRIPTION
Fixed multiple pre-render of the `Installation` page when selecting a new platform